### PR TITLE
Market Cleanup

### DIFF
--- a/config/farmingforblockheads-common.toml
+++ b/config/farmingforblockheads-common.toml
@@ -1,9 +1,9 @@
 #List of default presets to disable.
 disabledDefaultPresets = []
 #List of optional presets to enable.
-enabledOptionalPresets = ["minecraft:flowers", "minecraft:mushrooms"]
+enabledOptionalPresets = []
 #List of names the merchant can have.
-merchantNames = ["Swap-O-Matic", "Emerald Muncher", "Weathered Salesperson"]
+merchantNames = ["Swap-O-Matic", "Emerald Muncher", "Gold-Digger", "Weathered Salesperson"]
 #The range within animals can be fed by the feeding trough.
 #Range: > -2147483648
 feedingTroughRange = 8

--- a/kubejs/data/enigmatica/market_presets/market_trades.json
+++ b/kubejs/data/enigmatica/market_presets/market_trades.json
@@ -1,0 +1,4 @@
+{
+    "enabled": true,
+    "payment": { "ingredient": { "item": "minecraft:gold_nugget" }, "count": 3 }
+}

--- a/kubejs/data/occultism/market_presets/market_trades.json
+++ b/kubejs/data/occultism/market_presets/market_trades.json
@@ -1,0 +1,4 @@
+{
+    "enabled": true,
+    "payment": { "ingredient": { "item": "occultism:spirit_attuned_gem" }, "count": 1 }
+}

--- a/kubejs/server_scripts/constants/farmingforblockheads_preset_whitelist.js
+++ b/kubejs/server_scripts/constants/farmingforblockheads_preset_whitelist.js
@@ -1,0 +1,10 @@
+//priority: 1001
+
+const farmingforblockheads_preset_whitelist = [
+    'minecraft:mushrooms',
+    'minecraft:saplings',
+    'minecraft:flowers',
+    'minecraft:seed_crops',
+    'minecraft:crops',
+    'minecraft:seeds'
+];

--- a/kubejs/server_scripts/recipes/farmingforblockheads/market.js
+++ b/kubejs/server_scripts/recipes/farmingforblockheads/market.js
@@ -1,0 +1,31 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:farmingforblockheads/market/';
+    const recipes = [
+        {
+            category: 'farmingforblockheads:saplings',
+            preset: 'occultism:market_trades',
+            result: { count: 1, item: 'occultism:otherworld_sapling' },
+            id: `${id_prefix}otherworld_sapling`
+        }
+    ];
+
+    event.forEachRecipe({ type: 'farmingforblockheads:market' }, (r) => {
+        let recipe = JSON.parse(r.json);
+        let recipe_id = r.getId();
+
+        if (!farmingforblockheads_preset_whitelist.includes(recipe.preset)) {
+            event.remove({ id: recipe_id });
+        } else {
+            recipe.preset = 'enigmatica:market_trades';
+            recipe.id = `${id_prefix}${recipe_id.split('market/').pop()}`;
+            event.remove({ id: recipe_id });
+            recipes.push(recipe);
+        }
+    });
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'farmingforblockheads:market';
+        if (!recipe.preset) recipe.preset = 'enigmatica:market_trades';
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/recipes/farmingforblockheads/market.js
+++ b/kubejs/server_scripts/recipes/farmingforblockheads/market.js
@@ -21,6 +21,26 @@ ServerEvents.recipes((event) => {
             category: 'farmingforblockheads:saplings',
             result: { count: 1, item: 'minecraft:mangrove_propagule' },
             id: `${id_prefix}mangrove_propagule`
+        },
+        {
+            category: 'farmingforblockheads:saplings',
+            result: { count: 4, item: 'farmingforblockheads:green_fertilizer' },
+            id: `${id_prefix}green_fertilizer`
+        },
+        {
+            category: 'farmingforblockheads:saplings',
+            result: { count: 4, item: 'farmingforblockheads:red_fertilizer' },
+            id: `${id_prefix}red_fertilizer`
+        },
+        {
+            category: 'farmingforblockheads:saplings',
+            result: { count: 4, item: 'farmingforblockheads:yellow_fertilizer' },
+            id: `${id_prefix}yellow_fertilizer`
+        },
+        {
+            category: 'farmingforblockheads:saplings',
+            result: { count: 12, item: 'minecraft:bone_meal' },
+            id: `${id_prefix}bone_meal`
         }
     ];
 
@@ -28,14 +48,12 @@ ServerEvents.recipes((event) => {
         let recipe = JSON.parse(r.json);
         let recipe_id = r.getId();
 
-        if (!farmingforblockheads_preset_whitelist.includes(recipe.preset)) {
-            event.remove({ id: recipe_id });
-        } else {
+        if (farmingforblockheads_preset_whitelist.includes(recipe.preset)) {
             recipe.preset = 'enigmatica:market_trades';
             recipe.id = `${id_prefix}${recipe_id.split('market/').pop()}`;
-            event.remove({ id: recipe_id });
             recipes.push(recipe);
         }
+        event.remove({ id: recipe_id });
     });
 
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/recipes/farmingforblockheads/market.js
+++ b/kubejs/server_scripts/recipes/farmingforblockheads/market.js
@@ -14,6 +14,16 @@ ServerEvents.recipes((event) => {
         },
         {
             category: 'farmingforblockheads:seeds',
+            result: { count: 1, item: 'chococraft:gysahl_green_seeds' },
+            id: `${id_prefix}gysahl_green_seeds`
+        },
+        {
+            category: 'farmingforblockheads:seeds',
+            result: { count: 1, item: 'jags:grass_seed' },
+            id: `${id_prefix}grass_seed`
+        },
+        {
+            category: 'farmingforblockheads:seeds',
             result: { count: 1, item: 'minecraft:cocoa_beans' },
             id: `${id_prefix}cocoa_beans`
         },

--- a/kubejs/server_scripts/recipes/farmingforblockheads/market.js
+++ b/kubejs/server_scripts/recipes/farmingforblockheads/market.js
@@ -13,6 +13,11 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}datura_seeds`
         },
         {
+            category: 'farmingforblockheads:seeds',
+            result: { count: 1, item: 'minecraft:cocoa_beans' },
+            id: `${id_prefix}cocoa_beans`
+        },
+        {
             category: 'farmingforblockheads:saplings',
             result: { count: 1, item: 'arts_and_crafts:cork_sapling' },
             id: `${id_prefix}cork_sapling`

--- a/kubejs/server_scripts/recipes/farmingforblockheads/market.js
+++ b/kubejs/server_scripts/recipes/farmingforblockheads/market.js
@@ -23,22 +23,22 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}mangrove_propagule`
         },
         {
-            category: 'farmingforblockheads:saplings',
+            category: 'farmingforblockheads:other',
             result: { count: 4, item: 'farmingforblockheads:green_fertilizer' },
             id: `${id_prefix}green_fertilizer`
         },
         {
-            category: 'farmingforblockheads:saplings',
+            category: 'farmingforblockheads:other',
             result: { count: 4, item: 'farmingforblockheads:red_fertilizer' },
             id: `${id_prefix}red_fertilizer`
         },
         {
-            category: 'farmingforblockheads:saplings',
+            category: 'farmingforblockheads:other',
             result: { count: 4, item: 'farmingforblockheads:yellow_fertilizer' },
             id: `${id_prefix}yellow_fertilizer`
         },
         {
-            category: 'farmingforblockheads:saplings',
+            category: 'farmingforblockheads:other',
             result: { count: 12, item: 'minecraft:bone_meal' },
             id: `${id_prefix}bone_meal`
         }

--- a/kubejs/server_scripts/recipes/farmingforblockheads/market.js
+++ b/kubejs/server_scripts/recipes/farmingforblockheads/market.js
@@ -6,6 +6,21 @@ ServerEvents.recipes((event) => {
             preset: 'occultism:market_trades',
             result: { count: 1, item: 'occultism:otherworld_sapling' },
             id: `${id_prefix}otherworld_sapling`
+        },
+        {
+            category: 'farmingforblockheads:seeds',
+            result: { count: 1, item: 'occultism:datura_seeds' },
+            id: `${id_prefix}datura_seeds`
+        },
+        {
+            category: 'farmingforblockheads:saplings',
+            result: { count: 1, item: 'arts_and_crafts:cork_sapling' },
+            id: `${id_prefix}cork_sapling`
+        },
+        {
+            category: 'farmingforblockheads:saplings',
+            result: { count: 1, item: 'minecraft:mangrove_propagule' },
+            id: `${id_prefix}mangrove_propagule`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/occultism/ritual.js
+++ b/kubejs/server_scripts/recipes/occultism/ritual.js
@@ -1,0 +1,19 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:occultism/ritual/';
+    const recipes = [];
+
+    event.forEachRecipe({ type: 'occultism:ritual' }, (r) => {
+        let recipe = JSON.parse(r.json);
+        let recipe_id = r.getId();
+
+        // Override default craft time for all recipes
+        recipe.duration = 20;
+        recipe.id = recipe_id;
+        recipes.push(recipe);
+    });
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'occultism:ritual';
+        event.custom(recipe).id(recipe.id);
+    });
+});


### PR DESCRIPTION
Moves control of the Market to scripts instead of the config file. 

Removes recipes by ID for things that are disabled.

Replaces the price with gold nuggets instead of emeralds, as the Market is meant to give relatively easy access to seeds/saplings.

resolves: https://github.com/EnigmaticaModpacks/Enigmatica10/issues/11

Reduces crafting time at Occultism Pentacles to 1 second per input item instead of the normally very long craft times.