### PR TITLE
Fix Mekanism Metallurgic Infuser quest

### DIFF
--- a/config/ftbquests/quests/chapters/4D1E38918B64CD4E.snbt
+++ b/config/ftbquests/quests/chapters/4D1E38918B64CD4E.snbt
@@ -171,7 +171,7 @@
 				}
 				{
 					id: "256E76CA796C354E"
-					item: { count: 1, id: "mekanism:dust_steel" }
+					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(c:dusts/steel)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 					type: "item"
 				}
 			]


### PR DESCRIPTION
Require any steel dust instead of the one from Mekanism.