### PR TITLE
Mob Dispelling

### DIFF
--- a/kubejs/server_scripts/loot_tables/entities/enigmatica/dispel/possessed_endermite.js
+++ b/kubejs/server_scripts/loot_tables/entities/enigmatica/dispel/possessed_endermite.js
@@ -1,0 +1,8 @@
+// https://docs.almostreliable.com/lootjs/
+
+LootJS.lootTables((event) => {
+    event.create('enigmatica:entities/dispel/possessed_endermite').createPool((pool) => {
+        pool.addEntry(LootEntry.of('minecraft:elytra').setCount(1).withWeight(20));
+        pool.addEntry(LootEntry.reference('occultism:entities/possessed_endermite').withWeight(80));
+    });
+});

--- a/kubejs/server_scripts/recipe_viewer/info.js
+++ b/kubejs/server_scripts/recipe_viewer/info.js
@@ -77,6 +77,10 @@ RecipeViewerEvents.addInformation('item', (event) => {
                 '',
                 'Can spread to adjacent dirt blocks. Burns when exposed to daylight.'
             ]
+        },
+        {
+            filter: ['minecraft:elytra'],
+            text: ['Obtained occasionally when casting §aDispel§r on a §dPossessed Endermite§r.']
         }
     ];
 

--- a/kubejs/server_scripts/recipes/ars_nouveau/dispel_entity.js
+++ b/kubejs/server_scripts/recipes/ars_nouveau/dispel_entity.js
@@ -1,0 +1,17 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:ars_nouveau/dispel_entity/';
+
+    const recipes = [
+        {
+            entity: 'occultism:possessed_endermite',
+            loot_conditions: [],
+            loot_table: 'enigmatica:entities/dispel/possessed_endermite',
+            id: `${id_prefix}dispel_possessed_endermite`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'ars_nouveau:dispel_entity';
+        event.custom(recipe).id(recipe.id);
+    });
+});


### PR DESCRIPTION
Experimenting with Ars Nouveau's Dispel mechanic. This allows the player to randomly obtain an elytra from casting dispel on a possessed endermite.