### PR TITLE
EIO Compat and integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 -   Buffs Wireless Chargers [\#118](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/118)
 -   Otherworld logs can now be sawed in various machines [\#119](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/119)
 -   Add support for stripping logs with Farmer's Delight [\#125](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/125)
+-   Add enderman heads to beheading scripts and add Deeper Darker's axe to the list of valid tools [\#131](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/131)
+-   Unify Silicon for IF and EnderIO [\#131](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/131)
 
 #### 🦟 Bugs Fixed
 
@@ -19,6 +21,7 @@
 -   Restore missing metallurgic Infusing and enriching recipes [\#110](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/110)
 -   Fix broken stronghold locator [\#122](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/122)
 -   Fix broken sawing recipes [\#125](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/125)
+-   Remove duplicate potion recipes that have been re-added by Ars [\#131](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/131)
 
 ---
 

--- a/config/almostunified/unification/materials.json
+++ b/config/almostunified/unification/materials.json
@@ -1,5 +1,14 @@
 {
-    "mod_priorities": ["minecraft", "kubejs", "modern_industrialization", "mekanism", "occultism", "bigreactors"],
+    "mod_priorities": [
+        "minecraft",
+        "kubejs",
+        "modern_industrialization",
+        "mekanism",
+        "occultism",
+        "ae2",
+        "enderio",
+        "bigreactors"
+    ],
     "priority_overrides": {},
     "stone_variants": ["stone", "andesite", "deepslate", "diorite", "granite", "nether"],
     "tags": [
@@ -14,7 +23,8 @@
         "c:rods/{material}",
         "c:storage_blocks/raw_{material}",
         "c:storage_blocks/{material}",
-        "c:wires/{material}"
+        "c:wires/{material}",
+        "c:silicon"
     ],
     "ignored_tags": [],
     "ignored_items": [],

--- a/kubejs/server_scripts/constants/beheading_tools.js
+++ b/kubejs/server_scripts/constants/beheading_tools.js
@@ -6,6 +6,7 @@ const beheading_tools = [
     'justdirethings:eclipsealloy_axe',
     'aquaculture:neptunium_axe',
     'minecraft:netherite_axe',
+    'deeperdarker:warden_axe',
 
     'justdirethings:celestigem_paxel',
     'justdirethings:eclipsealloy_paxel',

--- a/kubejs/server_scripts/item_events/tooltips.js
+++ b/kubejs/server_scripts/item_events/tooltips.js
@@ -23,7 +23,11 @@ ItemEvents.modifyTooltips((event) => {
     */
     const recipes = [
         {
-            items: ['minecraft:reinforced_deepslate', 'modularrouters:blast_upgrade'],
+            items: [
+                'minecraft:reinforced_deepslate',
+                'modularrouters:blast_upgrade',
+                'enderio:reinforced_obsidian_block'
+            ],
             text: [Text.of('Wither Immune').lightPurple()]
         }
     ];

--- a/kubejs/server_scripts/loot_tables/entities/enigmatica/heads_from_beheading.js
+++ b/kubejs/server_scripts/loot_tables/entities/enigmatica/heads_from_beheading.js
@@ -8,7 +8,8 @@ LootJS.lootTables((event) => {
         { table: 'minecraft:entities/piglin', head: 'minecraft:piglin_head' },
         { table: 'minecraft:entities/piglin_brute', head: 'minecraft:piglin_head' },
         { table: 'minecraft:entities/skeleton', head: 'minecraft:skeleton_skull' },
-        { table: 'minecraft:entities/zombie', head: 'minecraft:zombie_head' }
+        { table: 'minecraft:entities/zombie', head: 'minecraft:zombie_head' },
+        { table: 'minecraft:entities/enderman', head: 'enderio:enderman_head' }
     ];
 
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/recipe_viewer/info.js
+++ b/kubejs/server_scripts/recipe_viewer/info.js
@@ -78,6 +78,10 @@ RecipeViewerEvents.addInformation('item', (event) => {
                 '',
                 'Can spread to adjacent dirt blocks. Burns when exposed to daylight.'
             ]
+        },
+        {
+            filter: ['enderio:industrial_insulation_block'],
+            text: ['Absorbs and voids any fluids placed nearby.']
         }
     ];
 

--- a/kubejs/server_scripts/recipe_viewer/info.js
+++ b/kubejs/server_scripts/recipe_viewer/info.js
@@ -44,7 +44,8 @@ RecipeViewerEvents.addInformation('item', (event) => {
                 'minecraft:piglin_head',
                 'minecraft:dragon_head',
                 'minecraft:skeleton_skull',
-                'minecraft:wither_skeleton_skull'
+                'minecraft:wither_skeleton_skull',
+                'enderio:enderman_head'
             ],
             text: ['Heads may be obtained from mobs by killing them with particularly powerful axes and paxels.']
         },

--- a/kubejs/server_scripts/recipe_viewer/info.js
+++ b/kubejs/server_scripts/recipe_viewer/info.js
@@ -47,7 +47,11 @@ RecipeViewerEvents.addInformation('item', (event) => {
                 'minecraft:wither_skeleton_skull',
                 'enderio:enderman_head'
             ],
-            text: ['Heads may be obtained from mobs by killing them with particularly powerful axes and paxels.']
+            text: [
+                'Heads may be obtained from mobs by killing them with particularly powerful axes and paxels.',
+                ' ',
+                'Search for §5#beheading§r in EMI for a list!'
+            ]
         },
         {
             filter: ['justdirethings:time_crystal'],

--- a/kubejs/server_scripts/recipes/enderio/soul_engine.js
+++ b/kubejs/server_scripts/recipes/enderio/soul_engine.js
@@ -21,13 +21,6 @@ ServerEvents.generateData('before_mods', (event) => {
             'power/mb': 450,
             'tick/mb': 10,
             id: `${id_prefix}magma_cube_blaze_ember`
-        },
-        {
-            entity: 'the_bumblezone:honey_slime',
-            fluid: '#c:fuels/hootch',
-            'power/mb': 600,
-            'tick/mb': 6,
-            id: `${id_prefix}honey_slime_hootch`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/enderio/soul_engine.js
+++ b/kubejs/server_scripts/recipes/enderio/soul_engine.js
@@ -1,0 +1,37 @@
+ServerEvents.generateData('before_mods', (event) => {
+    const id_prefix = 'enigmatica_soul_engine_';
+    let recipes = [
+        {
+            entity: 'deeperdarker:sculk_snapper',
+            fluid: '#c:fuels/eclipse_ember',
+            'power/mb': 4000,
+            'tick/mb': 10,
+            id: `${id_prefix}warden_eclipse_ember`
+        },
+        {
+            entity: 'minecraft:endermite',
+            fluid: '#c:fuels/voidflame',
+            'power/mb': 1300,
+            'tick/mb': 10,
+            id: `${id_prefix}endermite_voidflame`
+        },
+        {
+            entity: 'minecraft:magma_cube',
+            fluid: '#c:fuels/blaze_ember',
+            'power/mb': 450,
+            'tick/mb': 10,
+            id: `${id_prefix}magma_cube_blaze_ember`
+        },
+        {
+            entity: 'the_bumblezone:honey_slime',
+            fluid: '#c:fuels/hootch',
+            'power/mb': 600,
+            'tick/mb': 6,
+            id: `${id_prefix}honey_slime_hootch`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.json(`enderio:eio_soul/engine/${recipe.id}`, recipe);
+    });
+});

--- a/kubejs/server_scripts/recipes/minecraft/potion_brewing.js
+++ b/kubejs/server_scripts/recipes/minecraft/potion_brewing.js
@@ -3,11 +3,6 @@ MoreJS.registerPotionBrewing((event) => {
 
     const recipes = [
         {
-            reagent: 'ars_nouveau:abjuration_essence',
-            input: 'minecraft:water',
-            output: 'minecraft:awkward'
-        },
-        {
             reagent: 'ars_nouveau:fire_essence',
             input: 'minecraft:awkward',
             output: 'minecraft:fire_resistance'
@@ -72,52 +67,8 @@ MoreJS.registerPotionBrewing((event) => {
             reagent: 'minecraft:glowstone_dust',
             input: 'kubejs:resistance',
             output: 'kubejs:strong_resistance'
-        },
-        {
-            reagent: 'ars_nouveau:wilden_horn',
-            input: 'minecraft:water',
-            output: 'minecraft:strength'
-        },
-        {
-            reagent: 'ars_nouveau:wilden_spike',
-            input: 'minecraft:water',
-            output: 'minecraft:long_water_breathing'
-        },
-        {
-            reagent: 'ars_nouveau:wilden_wing',
-            input: 'minecraft:water',
-            output: 'minecraft:leaping'
         }
     ];
-
-    const ars_potions = [
-        { reagent: 'ars_nouveau:bastion_pod', type: 'shielding' },
-        { reagent: 'ars_nouveau:frostaya_pod', type: 'freezing' },
-        { reagent: 'ars_nouveau:bombegranate_pod', type: 'blasting' },
-        { reagent: 'ars_nouveau:mendosteen_pod', type: 'recovery' },
-        { reagent: 'ars_nouveau:magebloom', type: 'spell_damage' },
-        { reagent: 'ars_nouveau:sourceberry_bush', type: 'mana_regen' }
-    ];
-
-    ars_potions.forEach((potion) => {
-        recipes.push(
-            {
-                reagent: potion.reagent,
-                input: 'minecraft:awkward',
-                output: `ars_nouveau:${potion.type}_potion`
-            },
-            {
-                reagent: 'minecraft:redstone',
-                input: `ars_nouveau:${potion.type}_potion`,
-                output: `ars_nouveau:${potion.type}_potion_long`
-            },
-            {
-                reagent: 'minecraft:glowstone_dust',
-                input: `ars_nouveau:${potion.type}_potion`,
-                output: `ars_nouveau:${potion.type}_potion_strong`
-            }
-        );
-    });
 
     let greater_potions = [
         { output: 'kubejs:greater_strength', input: 'minecraft:strong_strength' },

--- a/kubejs/server_scripts/tags/entity_type/enderio/soul_vial_blacklist.js
+++ b/kubejs/server_scripts/tags/entity_type/enderio/soul_vial_blacklist.js
@@ -1,3 +1,3 @@
 ServerEvents.tags('entity_type', (event) => {
-    event.get('enderio:soul_vial_blacklist').add(['#enigmatica:mob_spawner_blacklist']);
+    event.get('enderio:soul_vial_blacklist').add(['#enigmatica:mob_spawner_blacklist']).remove('minecraft:warden');
 });

--- a/kubejs/server_scripts/tags/entity_type/enderio/soul_vial_blacklist.js
+++ b/kubejs/server_scripts/tags/entity_type/enderio/soul_vial_blacklist.js
@@ -1,0 +1,3 @@
+ServerEvents.tags('entity_type', (event) => {
+    event.get('enderio:soul_vial_blacklist').add(['#enigmatica:mob_spawner_blacklist']);
+});

--- a/kubejs/server_scripts/tags/entity_type/enigmatica/mob_spawner_blacklist.js
+++ b/kubejs/server_scripts/tags/entity_type/enigmatica/mob_spawner_blacklist.js
@@ -6,9 +6,15 @@ ServerEvents.tags('entity_type', (event) => {
             /ars_nouveau/,
             /pneumaticcraft.*drone/,
             /ars_elemental:.*_familiar/,
+            /ars_elemental:summon_/,
             /occultism/,
             /evilcraft/,
-            'tiab:accelerator'
+            'tiab:accelerator',
+            'minecraft:armor_stand',
+            'mekanism:robit',
+            'farmingforblockheads:merchant',
+            'pneumaticcraft:programmable_controller',
+            'justdirethings:decoy_entity'
         ])
         .remove([
             /ars_nouveau:wilden/,

--- a/kubejs/server_scripts/tags/fluids/neoforge/fuels.js
+++ b/kubejs/server_scripts/tags/fluids/neoforge/fuels.js
@@ -6,4 +6,8 @@ ServerEvents.tags('fluid', (event) => {
     event.get('c:fuels/blaze_ember').add(['justdirethings:refined_t2_fluid_source']);
     event.get('c:fuels/voidflame').add(['justdirethings:refined_t3_fluid_source']);
     event.get('c:fuels/eclipse_ember').add(['justdirethings:refined_t4_fluid_source']);
+    event.get('c:fuels/hootch').add(['enderio:fluid_hootch_still']);
+    event.get('c:fuels/rocket_fuel').add(['enderio:fluid_rocket_fuel_still']);
+    event.get('c:fuels/fire_water').add(['enderio:fluid_fire_water_still']);
+    event.get('c:fuels/dew_of_the_void').add(['enderio:fluid_dew_of_the_void_still']);
 });


### PR DESCRIPTION
- Add Enderman heads to our beheading scripts
- Unify Silicon
- Add soul vial blacklists
- Add a few more exclusions to the mob spawner list like summons and technical entities so they don't show in EIO soul vials
- Update beheading tools
- Experimental fuel entries for Soul Engine
- Remove duplicate potions we were adding now that they're fixed in base Ars Nouveau
- Add wither immune tooltip to reinforced obsidian