### PR TITLE
saw/sagmill recycle cables

### DIFF
--- a/kubejs/server_scripts/recipes/enigmatica/powah_recycling.js
+++ b/kubejs/server_scripts/recipes/enigmatica/powah_recycling.js
@@ -1,0 +1,68 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:powah_recycling/';
+    const recipes = [
+        {
+            input: { item: 'powah:energy_cable_starter', count: 12 },
+            primary: { item: 'powah:capacitor_basic_tiny', count: 1 },
+            secondary: { item: 'minecraft:iron_nugget', count: 2 }
+        },
+        {
+            input: { item: 'powah:energy_cable_basic', count: 12 },
+            primary: { item: 'powah:capacitor_basic', count: 1 },
+            secondary: { item: 'minecraft:iron_ingot', count: 2 }
+        },
+        {
+            input: { item: 'powah:energy_cable_hardened', count: 12 },
+            primary: { item: 'powah:capacitor_hardened', count: 1 },
+            secondary: { item: 'powah:steel_energized', count: 2 }
+        },
+        {
+            input: { item: 'powah:energy_cable_blazing', count: 12 },
+            primary: { item: 'powah:capacitor_blazing', count: 1 },
+            secondary: { item: 'powah:crystal_blazing', count: 2 }
+        },
+        {
+            input: { item: 'powah:energy_cable_niotic', count: 12 },
+            primary: { item: 'powah:capacitor_niotic', count: 1 },
+            secondary: { item: 'powah:crystal_niotic', count: 2 }
+        },
+        {
+            input: { item: 'powah:energy_cable_spirited', count: 12 },
+            primary: { item: 'powah:capacitor_spirited', count: 1 },
+            secondary: { item: 'powah:crystal_spirited', count: 2 }
+        },
+        {
+            input: { item: 'powah:energy_cable_nitro', count: 12 },
+            primary: { item: 'powah:capacitor_nitro', count: 1 },
+            secondary: { item: 'powah:crystal_nitro', count: 2 }
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event
+            .custom({
+                type: 'mekanism:sawing',
+                input: recipe.input,
+                main_output: { id: recipe.primary.item, count: recipe.primary.count },
+                secondary_output: { id: recipe.secondary.item, count: recipe.secondary.count },
+                secondary_chance: 1
+            })
+            .id(`${id_prefix}sawing/${recipe.input.item.replace(':', '_')}`);
+
+        event
+            .custom({
+                type: 'enderio:sag_milling',
+                input: recipe.input,
+                outputs: [
+                    { item: { id: recipe.primary.item, count: recipe.primary.count }, chance: 1 / recipe.input.count },
+                    {
+                        item: { id: recipe.secondary.item, count: recipe.secondary.count },
+                        chance: 1 / recipe.input.count
+                    }
+                ],
+                bonus: 'none',
+                energy: 2400
+            })
+            .id(`${id_prefix}sag_milling/${recipe.input.item.replace(':', '_')}`);
+    });
+});

--- a/kubejs/server_scripts/recipes/enigmatica/powah_recycling.js
+++ b/kubejs/server_scripts/recipes/enigmatica/powah_recycling.js
@@ -35,6 +35,42 @@ ServerEvents.recipes((event) => {
             input: { item: 'powah:energy_cable_nitro', count: 12 },
             primary: { item: 'powah:capacitor_nitro', count: 1 },
             secondary: { item: 'powah:crystal_nitro', count: 2 }
+        },
+
+        {
+            input: { item: 'powah:ender_cell_starter', count: 1 },
+            primary: { item: 'powah:ender_core', count: 1 },
+            secondary: { item: 'minecraft:iron_nugget', count: 4 }
+        },
+        {
+            input: { item: 'powah:ender_cell_basic', count: 1 },
+            primary: { item: 'powah:ender_core', count: 1 },
+            secondary: { item: 'minecraft:iron_ingot', count: 4 }
+        },
+        {
+            input: { item: 'powah:ender_cell_hardened', count: 1 },
+            primary: { item: 'powah:ender_core', count: 1 },
+            secondary: { item: 'powah:steel_energized', count: 4 }
+        },
+        {
+            input: { item: 'powah:ender_cell_blazing', count: 1 },
+            primary: { item: 'powah:ender_core', count: 1 },
+            secondary: { item: 'powah:crystal_blazing', count: 4 }
+        },
+        {
+            input: { item: 'powah:ender_cell_niotic', count: 1 },
+            primary: { item: 'powah:ender_core', count: 1 },
+            secondary: { item: 'powah:crystal_niotic', count: 4 }
+        },
+        {
+            input: { item: 'powah:ender_cell_spirited', count: 1 },
+            primary: { item: 'powah:ender_core', count: 1 },
+            secondary: { item: 'powah:crystal_spirited', count: 4 }
+        },
+        {
+            input: { item: 'powah:ender_cell_nitro', count: 1 },
+            primary: { item: 'powah:ender_core', count: 1 },
+            secondary: { item: 'powah:crystal_nitro', count: 4 }
         }
     ];
 

--- a/kubejs/server_scripts/recipes/enigmatica/remove.js
+++ b/kubejs/server_scripts/recipes/enigmatica/remove.js
@@ -12,7 +12,8 @@ ServerEvents.recipes((event) => {
         { id: 'mffs:steel_compound' },
         { type: 'evilcraft:special/minecraft_dead_bush' },
         { id: `enderio:sag_milling/blaze_powder` },
-        { id: `mekanism:sulfur_dye` }
+        { id: `mekanism:sulfur_dye` },
+        { id: /powah:crafting\/cable_(basic|hardened|blazing|niotic|spirited|nitro)$/ }
     ];
 
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/recipes/enigmatica/shapeless.js
+++ b/kubejs/server_scripts/recipes/enigmatica/shapeless.js
@@ -74,5 +74,6 @@ ServerEvents.recipes((event) => {
     recipes.forEach((recipe) => {
         let r = event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
         if (recipe.damage) r.damageIngredient(recipe.damage.item, recipe.damage.amount);
+        if (recipe.replace) r.replaceIngredient(recipe.replace.item, recipe.replace.replacement);
     });
 });


### PR DESCRIPTION
Recycling idea for https://github.com/EnigmaticaModpacks/Enigmatica10/issues/159

The idea here is to just remove the costly upgrades and let the player recycle old cables for re-use. The items are most likely going to end up in an energy cell, I'd wager, but they should find use somewhere. 

Cables can be recycled through the Saw Mill and Sag Mill 
![image](https://github.com/user-attachments/assets/6717239b-430c-46c7-9d58-539066e7a74d)
![image](https://github.com/user-attachments/assets/13f14f42-c767-4df3-a8b1-5167f49cf443)

I'm not super keen on the SAG Mill here, as it is random. But figured I'd include it for feedback.

For example, 120 spirited cables needs 20 spirited crystals and 10 spirited capacitors to craft. Running that many through the SAG Mill got me 22 crystals and 7 capacitors. I'd expect this to be somewhat lossy in general. 

