### PR TITLE
Add items from latest update to replicatior blacklist

### DIFF
--- a/kubejs/server_scripts/tags/item/modern_industrialization/replicator_blacklist.js
+++ b/kubejs/server_scripts/tags/item/modern_industrialization/replicator_blacklist.js
@@ -20,7 +20,8 @@ ServerEvents.tags('item', (event) => {
         'ars_elemental:caster_bag',
         'ars_additions:handy_haversack',
         'evilcraft:dark_tank',
-        'shrink:shrink_bottle'
+        'shrink:shrink_bottle',
+        'enderio:vacuum_chest'
     ];
 
     let exclusions = [

--- a/kubejs/server_scripts/tags/item/modern_industrialization/replicator_blacklist.js
+++ b/kubejs/server_scripts/tags/item/modern_industrialization/replicator_blacklist.js
@@ -9,6 +9,8 @@ ServerEvents.tags('item', (event) => {
         /mekanism:.*_(chest|tank|barrel)/,
         /mekanism:.*_bin$/,
         /mekanism:qio_drive/,
+        /occultism:ritual_satchel_t\d/,
+        /enderio:(pressurized_)?fluid_tank/,
         'ae2:view_cell',
         'occultism:storage_controller',
         'mekanism:cardboard_box',
@@ -21,7 +23,9 @@ ServerEvents.tags('item', (event) => {
         'ars_additions:handy_haversack',
         'evilcraft:dark_tank',
         'shrink:shrink_bottle',
-        'enderio:vacuum_chest'
+        'enderio:crafter',
+        'enderio:vacuum_chest',
+        'toolbelt:belt'
     ];
 
     let exclusions = [


### PR DESCRIPTION
The EnderIO Vacuum Chest and Crafter keep their inventory when broken, so they should be blacklisted to prevent arbitrary duping.

The new Occultism Ritual Satchels, Tool Belt, and EnderIO tanks were also added.