### PR TITLE
Small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   AA Lasers no longer lose power during transmission [\#196](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/196)
 -   Tiny TNT no longer breaks blocks, making it safer for crafting [\#196](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/196)
 -   Glow Berries are now a source for yellow dye [\#196](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/196)
+-   The Market has dropped their prices once again! Rejoice! [\#196](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/196)
 
 #### 🦟 Bugs Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
-### Enigmatica 10 1.12.1
+### Enigmatica 10 1.13.0
+
+#### ⭐ Improvements
+
+-   Rice Slime Balls now count as slime balls for more recipes [\#196](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/196)
+-   Expanded fuel support for AA, allowing it to burn more coal like substances [\#196](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/196)
+-   Added more cross mod crushing compatibility [\#196](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/196)
+-   AA Lasers no longer lose power during transmission [\#196](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/196)
+-   Tiny TNT no longer breaks blocks, making it safer for crafting [\#196](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/196)
+-   Glow Berries are now a source for yellow dye [\#196](https://github.com/EnigmaticaModpacks/Enigmatica10/pull/196)
 
 #### 🦟 Bugs Fixed
 
 -   Fixed broken logistics quests and a missing icon in genetics quests [(\#195)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/195)
 -   Unbound Marid no longer blacklisted from spawners [(\#195)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/195)
+-   Add missing Tin processing recipes [(\#196)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/196)
 
 ---
 

--- a/config/actuallyadditions-common.toml
+++ b/config/actuallyadditions-common.toml
@@ -56,7 +56,7 @@
 	#Range: > 1
 	minerLensEnergy = 60000
 	#If Energy Laser Relays should have energy loss.
-	laserRelayLoss = true
+	laserRelayLoss = false
 	#The cooldown between two generation cycles of the Leaf Generator, in ticks
 	#Range: > 1
 	leafGeneratorCooldown = 5

--- a/config/ae2-common.toml
+++ b/config/ae2-common.toml
@@ -3,7 +3,7 @@
 	#Enables the ability of the Matter Cannon to break blocks.
 	matterCannonBlockDamage = true
 	#Enables the ability of Tiny TNT to break blocks.
-	tinyTntBlockDamage = true
+	tinyTntBlockDamage = false
 	#Changes the channel capacity that cables provide in AE2.
 	#Allowed Values: INFINITE, DEFAULT, X2, X3, X4
 	channels = "DEFAULT"

--- a/config/ftbquests/quests/chapters/0095002B3E34FD9A.snbt
+++ b/config/ftbquests/quests/chapters/0095002B3E34FD9A.snbt
@@ -902,5 +902,22 @@
 			x: 5.5d
 			y: 4.0d
 		}
+		{
+			dependencies: ["5BD04F0109CB6704"]
+			id: "586D65D7CC2B8FCF"
+			rewards: [{
+				exclude_from_claim_all: true
+				id: "62443C7DB450BAB0"
+				table_id: 2884263910044023563L
+				type: "loot"
+			}]
+			tasks: [{
+				id: "72396A76EEA759CF"
+				item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(occultism:books/books_of_binding)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
+				type: "item"
+			}]
+			x: 2.5d
+			y: -2.0d
+		}
 	]
 }

--- a/config/ftbquests/quests/lang/en_us.snbt
+++ b/config/ftbquests/quests/lang/en_us.snbt
@@ -2906,6 +2906,17 @@
 		"There should be plenty of these inside the Maze to help you keep the buff up while you explore. "
 	]
 	quest.5859B0217F1C837A.quest_desc: ["With an Aura Attraction Cart, Aura may be pulled from a centralized Generator and dispersed throughout an area to power machines that might be too far away to otherwise benefit from the Generator. "]
+	quest.586D65D7CC2B8FCF.quest_desc: [
+		"As you get into the intricacies of spirit summoning, you may decide that you wish to automate some of these rituals. Since names on books are random, this can make things slightly incompatible with AE2."
+		""
+		"By renaming the Dictionary of Spirits in an Anvil, all books bound with it will take on that name, resolving this small issue. So AE2 should have no issue with crafting bound books. "
+		""
+		"&6⚠ Note: Job spirits summoned in this "
+		"&6    way will be owned by the AE2 "
+		"&6    system’s fake player, making them "
+		"&6    uncontrollable. This is best used "
+		"&6    for crafting items."
+	]
 	quest.59293885E5C9E8A3.quest_desc: [
 		"A simple machine used for crushing ores and other materials. "
 		""
@@ -4296,6 +4307,7 @@
 	task.6F72D2074543BF23.title: "Bins"
 	task.700A9968FA0DA65E.title: "Player Transmitters"
 	task.70531464F6943384.title: "Pattern Terminals"
+	task.72396A76EEA759CF.title: "Books of Binding"
 	task.73C57E2AF9A1F920.title: "Any Chipped Tool"
 	task.73D7073169A23821.title: "WIP"
 	task.741114ACD8AABEF6.title: "Demon's Dream"

--- a/config/ftbquests/quests/reward_tables/2806F6BEA4A73B0B.snbt
+++ b/config/ftbquests/quests/reward_tables/2806F6BEA4A73B0B.snbt
@@ -27,12 +27,28 @@
 			random_bonus: 4
 		}
 		{
-			count: 8
+			count: 4
 			item: {
 				count: 1
 				id: "occultism:book_of_binding_empty"
 			}
-			random_bonus: 8
+			random_bonus: 4
+		}
+		{
+			count: 2
+			item: {
+				count: 1
+				id: "occultism:spirit_attuned_gem"
+			}
+			random_bonus: 2
+		}
+		{
+			count: 16
+			item: {
+				count: 1
+				id: "occultism:otherworld_log"
+			}
+			random_bonus: 32
 		}
 	]
 	use_title: true

--- a/kubejs/server_scripts/recipes/actuallyadditions/crushing.js
+++ b/kubejs/server_scripts/recipes/actuallyadditions/crushing.js
@@ -32,6 +32,21 @@ ServerEvents.recipes((event) => {
             ingredient: { tag: `c:gems/lignite_coal` },
             result: [{ result: { id: AlmostUnified.getTagTargetItem(`c:dusts/lignite_coal`).getId(), count: 1 } }],
             id: `${id_prefix}lignite_coal_dust`
+        },
+        {
+            ingredient: { item: 'minecraft:glow_berries' },
+            result: [{ result: { id: 'minecraft:yellow_dye', count: 2 } }],
+            id: `${id_prefix}yellow_dye_from_glow_berries`
+        },
+        {
+            ingredient: { item: 'minecraft:ender_pearl' },
+            result: [{ result: { id: AlmostUnified.getTagTargetItem(`c:dusts/ender_pearl`).getId(), count: 1 } }],
+            id: `${id_prefix}ender_pearl_dust`
+        },
+        {
+            ingredient: { item: 'ae2:sky_stone_block' },
+            result: [{ result: { id: 'ae2:sky_dust', count: 1 } }],
+            id: `${id_prefix}sky_dust`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/actuallyadditions/crushing.js
+++ b/kubejs/server_scripts/recipes/actuallyadditions/crushing.js
@@ -35,6 +35,7 @@ ServerEvents.recipes((event) => {
         { primary: 'lead', secondary: 'silver' },
         { primary: 'silver', secondary: 'lead' },
         { primary: 'nickel', secondary: 'iron' },
+        { primary: 'tin', secondary: 'iron' },
         { primary: 'uranium', secondary: 'lead' }
     ];
     materials.forEach((material) => {

--- a/kubejs/server_scripts/recipes/actuallyadditions/crushing.js
+++ b/kubejs/server_scripts/recipes/actuallyadditions/crushing.js
@@ -22,6 +22,16 @@ ServerEvents.recipes((event) => {
             ingredient: { tag: `c:gems/fluix` },
             result: [{ result: { id: 'ae2:fluix_dust', count: 1 } }],
             id: `${id_prefix}fluix_dust`
+        },
+        {
+            ingredient: { tag: `c:gems/coal` },
+            result: [{ result: { id: AlmostUnified.getTagTargetItem(`c:dusts/coal`).getId(), count: 1 } }],
+            id: `${id_prefix}coal_dust`
+        },
+        {
+            ingredient: { tag: `c:gems/lignite_coal` },
+            result: [{ result: { id: AlmostUnified.getTagTargetItem(`c:dusts/lignite_coal`).getId(), count: 1 } }],
+            id: `${id_prefix}lignite_coal_dust`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/actuallyadditions/liquid_fuel.js
+++ b/kubejs/server_scripts/recipes/actuallyadditions/liquid_fuel.js
@@ -1,0 +1,33 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:actuallyadditions/liquid_fuel/';
+
+    const recipes = [
+        {
+            fuel: 'justdirethings:refined_t2_fluid_source',
+            fe_per_mb: 450,
+            fe_per_tick: 100,
+            id: `${id_prefix}refined_t2_fluid_source`
+        },
+        {
+            fuel: 'justdirethings:refined_t3_fluid_source',
+            fe_per_mb: 1300,
+            fe_per_tick: 130,
+            id: `${id_prefix}refined_t3_fluid_source`
+        },
+        {
+            fuel: 'justdirethings:refined_t4_fluid_source',
+            fe_per_mb: 4000,
+            fe_per_tick: 160,
+            id: `${id_prefix}refined_t4_fluid_source`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'actuallyadditions:liquid_fuel';
+        let burn_amount = 50;
+        recipe.fuel = { id: recipe.fuel, amount: burn_amount };
+        recipe.total_energy = recipe.fe_per_mb * burn_amount;
+        recipe.burn_time = recipe.total_energy / recipe.fe_per_tick;
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/recipes/actuallyadditions/solid_fuel.js
+++ b/kubejs/server_scripts/recipes/actuallyadditions/solid_fuel.js
@@ -1,0 +1,53 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:actuallyadditions/solid_fuel/';
+
+    const recipes = [
+        {
+            item: { tag: 'c:gems/lignite_coal' },
+            burn_time: 1600,
+            total_energy: 32000,
+            id: `${id_prefix}lignite_coal`
+        },
+        {
+            item: { item: 'c:storage_blocks/lignite_coal' },
+            burn_time: 16000,
+            total_energy: 320000,
+            id: `${id_prefix}lignite_coal_block`
+        },
+        {
+            item: { tag: 'c:dusts/charcoal' },
+            burn_time: 1600,
+            total_energy: 32000,
+            id: `${id_prefix}charcoal_dust`
+        },
+        {
+            item: { tag: 'c:dusts/coal' },
+            burn_time: 1600,
+            total_energy: 32000,
+            id: `${id_prefix}coal_dust`
+        },
+        {
+            item: { tag: 'c:dusts/lignite_coal' },
+            burn_time: 1600,
+            total_energy: 32000,
+            id: `${id_prefix}lignite_coal_dust`
+        },
+        {
+            item: { tag: 'c:tiny_dusts/coal' },
+            burn_time: 1600,
+            total_energy: 32000,
+            id: `${id_prefix}coal_tiny_dust`
+        },
+        {
+            item: { tag: 'c:tiny_dusts/lignite_coal' },
+            burn_time: 1600,
+            total_energy: 32000,
+            id: `${id_prefix}lignite_coal_tiny_dust`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'actuallyadditions:solid_fuel';
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/recipes/actuallyadditions/solid_fuel.js
+++ b/kubejs/server_scripts/recipes/actuallyadditions/solid_fuel.js
@@ -4,50 +4,97 @@ ServerEvents.recipes((event) => {
     const recipes = [
         {
             item: { tag: 'c:gems/lignite_coal' },
-            burn_time: 1600,
-            total_energy: 32000,
+            fuel_quality: 8,
             id: `${id_prefix}lignite_coal`
         },
         {
-            item: { item: 'c:storage_blocks/lignite_coal' },
-            burn_time: 16000,
-            total_energy: 320000,
+            item: { tag: 'c:storage_blocks/charcoal' },
+            fuel_quality: 80,
+            id: `${id_prefix}charcoal_block`
+        },
+        {
+            item: { tag: 'c:storage_blocks/lignite_coal' },
+            fuel_quality: 80,
             id: `${id_prefix}lignite_coal_block`
         },
         {
             item: { tag: 'c:dusts/charcoal' },
-            burn_time: 1600,
-            total_energy: 32000,
+            fuel_quality: 8,
             id: `${id_prefix}charcoal_dust`
         },
         {
             item: { tag: 'c:dusts/coal' },
-            burn_time: 1600,
-            total_energy: 32000,
+            fuel_quality: 8,
             id: `${id_prefix}coal_dust`
         },
         {
             item: { tag: 'c:dusts/lignite_coal' },
-            burn_time: 1600,
-            total_energy: 32000,
+            fuel_quality: 8,
             id: `${id_prefix}lignite_coal_dust`
         },
         {
             item: { tag: 'c:tiny_dusts/coal' },
-            burn_time: 1600,
-            total_energy: 32000,
+            fuel_quality: 0.8,
             id: `${id_prefix}coal_tiny_dust`
         },
         {
             item: { tag: 'c:tiny_dusts/lignite_coal' },
-            burn_time: 1600,
-            total_energy: 32000,
+            fuel_quality: 0.8,
             id: `${id_prefix}lignite_coal_tiny_dust`
+        },
+        {
+            item: { item: 'evilcraft:blood_waxed_coal' },
+            fuel_quality: 16,
+            id: `${id_prefix}blood_waxed_coal`
+        },
+        {
+            item: { tag: 'c:gems/primal_coal' },
+            fuel_quality: 24,
+            id: `${id_prefix}primal_coal`
+        },
+        {
+            item: { tag: 'c:gems/blaze_ember' },
+            fuel_quality: 72,
+            id: `${id_prefix}blaze_ember`
+        },
+        {
+            item: { tag: 'c:gems/voidflame' },
+            fuel_quality: 216,
+            id: `${id_prefix}voidflame`
+        },
+        {
+            item: { tag: 'c:gems/eclipse_ember' },
+            fuel_quality: 648,
+            id: `${id_prefix}eclipse_ember`
+        },
+        {
+            item: { tag: 'c:storage_blocks/primal_coal' },
+            fuel_quality: 240,
+            id: `${id_prefix}primal_coal_block`
+        },
+        {
+            item: { tag: 'c:storage_blocks/blaze_ember' },
+            fuel_quality: 720,
+            id: `${id_prefix}blaze_ember_block`
+        },
+        {
+            item: { tag: 'c:storage_blocks/voidflame' },
+            fuel_quality: 2160,
+            id: `${id_prefix}voidflame_block`
+        },
+        {
+            item: { tag: 'c:storage_blocks/eclipse_ember' },
+            fuel_quality: 6480,
+            id: `${id_prefix}eclipse_ember_block`
         }
     ];
 
     recipes.forEach((recipe) => {
         recipe.type = 'actuallyadditions:solid_fuel';
+        if (recipe.fuel_quality) {
+            recipe.burn_time = recipe.fuel_quality * 200;
+            recipe.total_energy = recipe.fuel_quality * 4000;
+        }
         event.custom(recipe).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/recipes/ars_nouveau/crushing.js
+++ b/kubejs/server_scripts/recipes/ars_nouveau/crushing.js
@@ -36,6 +36,7 @@ ServerEvents.recipes((event) => {
         { primary: 'lead', secondary: 'silver' },
         { primary: 'silver', secondary: 'lead' },
         { primary: 'nickel', secondary: 'iron' },
+        { primary: 'tin', secondary: 'iron' },
         { primary: 'uranium', secondary: 'lead' }
     ];
     materials.forEach((material) => {

--- a/kubejs/server_scripts/recipes/ars_nouveau/crushing.js
+++ b/kubejs/server_scripts/recipes/ars_nouveau/crushing.js
@@ -45,6 +45,39 @@ ServerEvents.recipes((event) => {
                 }
             ],
             id: `${id_prefix}lignite_coal_dust`
+        },
+        {
+            input: { item: 'minecraft:glow_berries' },
+            output: [
+                {
+                    stack: { id: 'minecraft:yellow_dye', count: 2 },
+                    chance: 1.0,
+                    maxRange: 1
+                }
+            ],
+            id: `${id_prefix}yellow_dye_from_glow_berries`
+        },
+        {
+            input: { item: 'minecraft:ender_pearl' },
+            output: [
+                {
+                    stack: { id: AlmostUnified.getTagTargetItem(`c:dusts/ender_pearl`).getId(), count: 1 },
+                    chance: 1.0,
+                    maxRange: 1
+                }
+            ],
+            id: `${id_prefix}ender_pearl_dust`
+        },
+        {
+            input: { item: 'ae2:sky_stone_block' },
+            output: [
+                {
+                    stack: { id: 'ae2:sky_dust', count: 1 },
+                    chance: 1.0,
+                    maxRange: 1
+                }
+            ],
+            id: `${id_prefix}sky_dust`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/ars_nouveau/crushing.js
+++ b/kubejs/server_scripts/recipes/ars_nouveau/crushing.js
@@ -23,6 +23,28 @@ ServerEvents.recipes((event) => {
                 }
             ],
             id: `${id_prefix}fluix_dust`
+        },
+        {
+            input: { tag: `c:gems/coal` },
+            output: [
+                {
+                    stack: { id: AlmostUnified.getTagTargetItem(`c:dusts/coal`).getId(), count: 1 },
+                    chance: 1.0,
+                    maxRange: 1
+                }
+            ],
+            id: `${id_prefix}coal_dust`
+        },
+        {
+            input: { tag: `c:gems/lignite_coal` },
+            output: [
+                {
+                    stack: { id: AlmostUnified.getTagTargetItem(`c:dusts/lignite_coal`).getId(), count: 1 },
+                    chance: 1.0,
+                    maxRange: 1
+                }
+            ],
+            id: `${id_prefix}lignite_coal_dust`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/cobblegengalore/blockgen.js
+++ b/kubejs/server_scripts/recipes/cobblegengalore/blockgen.js
@@ -36,7 +36,7 @@ ServerEvents.recipes((event) => {
         stoneworks[type].forEach((block) => {
             recipes.push({
                 result: { id: block, count: 1 },
-                left: { id: 'minecraft:water', consume: block == 'stones' ? true : false },
+                left: { id: 'minecraft:water', consume: block == false },
                 right: { id: 'minecraft:lava', consume: false },
                 bottom: block,
                 id: `${id_prefix}${block.replace(':', '_')}`

--- a/kubejs/server_scripts/recipes/cobblegengalore/blockgen.js
+++ b/kubejs/server_scripts/recipes/cobblegengalore/blockgen.js
@@ -19,7 +19,7 @@ ServerEvents.recipes((event) => {
         {
             result: { id: 'minecraft:obsidian', count: 1 },
             left: { id: 'minecraft:water', consume: false },
-            right: { id: 'minecraft:lava', consume: true },
+            right: { id: 'minecraft:lava', consume: false },
             bottom: 'minecraft:obsidian',
             id: `${id_prefix}obsidian`
         },

--- a/kubejs/server_scripts/recipes/enderio/sag_milling.js
+++ b/kubejs/server_scripts/recipes/enderio/sag_milling.js
@@ -107,6 +107,26 @@ ServerEvents.recipes((event) => {
             ],
             energy: 2400,
             id: `enderio:sag_milling/sand`
+        },
+        {
+            input: { item: 'minecraft:glow_berries' },
+            outputs: [
+                { item: { id: 'minecraft:yellow_dye', count: 1 }, chance: 0.8 },
+                {
+                    item: { id: 'minecraft:yellow_dye', count: 1 },
+                    chance: 0.6
+                },
+                {
+                    item: { id: 'minecraft:yellow_dye', count: 1 },
+                    chance: 0.3
+                },
+                {
+                    item: { id: 'enderio:plant_matter_green', count: 1 },
+                    chance: 0.1
+                }
+            ],
+            energy: 2400,
+            id: `${id_prefix}yellow_dye_from_glow_berries`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/enigmatica/shapeless.js
+++ b/kubejs/server_scripts/recipes/enigmatica/shapeless.js
@@ -38,6 +38,11 @@ ServerEvents.recipes((event) => {
             id: `${id_prefix}yellow_dye_from_fustic`
         },
         {
+            output: 'minecraft:yellow_dye',
+            inputs: ['minecraft:glow_berries'],
+            id: `${id_prefix}yellow_dye_from_glow_berries`
+        },
+        {
             output: 'minecraft:red_dye',
             inputs: ['productivetrees:dracaena_sap'],
             id: `${id_prefix}red_dye_from_dracaena_sap`

--- a/kubejs/server_scripts/recipes/farmersdelight/cutting.js
+++ b/kubejs/server_scripts/recipes/farmersdelight/cutting.js
@@ -1,7 +1,14 @@
 ServerEvents.recipes((event) => {
     const id_prefix = 'enigmatica:farmersdelight/cutting/';
 
-    const recipes = [];
+    const recipes = [
+        {
+            ingredients: [{ item: 'minecraft:glow_berries' }],
+            result: [{ item: { id: 'minecraft:yellow_dye', count: 2 } }],
+            tool: { tag: 'c:tools/knife' },
+            id: `${id_prefix}yellow_dye_from_glow_berries`
+        }
+    ];
 
     wood_registry.forEach((r) => {
         recipes.push(

--- a/kubejs/server_scripts/recipes/farmingforblockheads/market_presets.js
+++ b/kubejs/server_scripts/recipes/farmingforblockheads/market_presets.js
@@ -17,7 +17,7 @@ ServerEvents.generateData('before_mods', (event) => {
                 ingredient: {
                     item: 'minecraft:gold_nugget'
                 },
-                count: 3
+                count: 1
             }
         },
         {

--- a/kubejs/server_scripts/recipes/mekanism/enriching.js
+++ b/kubejs/server_scripts/recipes/mekanism/enriching.js
@@ -16,6 +16,11 @@ ServerEvents.recipes((event) => {
             input: { count: 1, tag: 'c:ores/black_quartz' },
             output: { count: 2, id: 'actuallyadditions:black_quartz' },
             id: `${id_prefix}black_quartz`
+        },
+        {
+            input: { count: 1, item: 'minecraft:glow_berries' },
+            output: { count: 2, id: 'minecraft:yellow_dye' },
+            id: `${id_prefix}yellow_dye_from_glow_berries`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/minecraft/compostable.js
+++ b/kubejs/server_scripts/recipes/minecraft/compostable.js
@@ -1,16 +1,13 @@
 const compostables = [
-    {
-        input: 'minecraft:egg',
-        chance: 0.35
-    },
-    {
-        input: '#c:foods/raw_meat',
-        chance: 0.65
-    },
-    {
-        input: '#c:foods/safe_raw_fish',
-        chance: 0.45
-    }
+    { input: 'minecraft:egg', chance: 0.35 },
+    { input: '#c:foods/raw_meat', chance: 0.65 },
+    { input: '#c:foods/safe_raw_fish', chance: 0.45 },
+    { input: 'actuallyadditions:rice_seeds', chance: 0.35 },
+    { input: 'actuallyadditions:canola_seeds', chance: 0.35 },
+    { input: 'actuallyadditions:flax_seeds', chance: 0.35 },
+    { input: 'actuallyadditions:coffee_beans', chance: 0.35 },
+    { input: 'actuallyadditions:rice', chance: 0.65 },
+    { input: 'actuallyadditions:canola', chance: 0.65 }
 ];
 
 ServerEvents.compostableRecipes((event) => {
@@ -27,5 +24,5 @@ ServerEvents.generateData('before_mods', (event) => {
         data_map.values[compostable.input] = { chance: compostable.chance };
     });
 
-    event.json(`neoforge:data_maps/item/compostables.json`, data_map);
+    event.json(`neoforge:data_maps/item/compostables`, data_map);
 });

--- a/kubejs/server_scripts/recipes/modern_industrialization/macerator.js
+++ b/kubejs/server_scripts/recipes/modern_industrialization/macerator.js
@@ -15,6 +15,13 @@ ServerEvents.recipes((event) => {
             eu: 2,
             duration: 800,
             id: `${id_prefix}plutonium_dust`
+        },
+        {
+            item_inputs: { item: 'minecraft:glow_berries', amount: 1 },
+            item_outputs: { item: 'minecraft:yellow_dye', amount: 2 },
+            eu: 2,
+            duration: 100,
+            id: `${id_prefix}yellow_dye_from_glow_berries`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/naturesaura/altar.js
+++ b/kubejs/server_scripts/recipes/naturesaura/altar.js
@@ -9,6 +9,14 @@ ServerEvents.recipes((event) => {
             aura: 5000,
             time: 20,
             id: `${id_prefix}nautilus_shell`
+        },
+        {
+            input: { item: 'minecraft:glow_berries' },
+            output: { id: 'minecraft:glowstone_dust' },
+            catalyst: { item: 'naturesaura:crushing_catalyst' },
+            aura: 5000,
+            time: 20,
+            id: `${id_prefix}glowstone_dust`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/naturesaura/shaped.js
+++ b/kubejs/server_scripts/recipes/naturesaura/shaped.js
@@ -1,5 +1,5 @@
 ServerEvents.recipes((event) => {
-    const id_prefix = 'pneumaticcraft:handcrafted/shaped/';
+    const id_prefix = 'pneumaticcraft:naturesaura/shaped/';
 
     const recipes = [
         {

--- a/kubejs/server_scripts/recipes/occultism/crushing.js
+++ b/kubejs/server_scripts/recipes/occultism/crushing.js
@@ -61,6 +61,16 @@ ServerEvents.recipes((event) => {
                 count: 1
             },
             id: `${id_prefix}glowstone_dust`
+        },
+        {
+            ingredient: { tag: `c:gems/fluix` },
+            ignore_crushing_multiplier: true,
+            result: {
+                type: 'occultism:item',
+                id: 'ae2:fluix_dust',
+                count: 1
+            },
+            id: `${id_prefix}fluix_dust`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/occultism/crushing.js
+++ b/kubejs/server_scripts/recipes/occultism/crushing.js
@@ -81,6 +81,26 @@ ServerEvents.recipes((event) => {
                 count: 1
             },
             id: `${id_prefix}fluix_dust`
+        },
+        {
+            ingredient: { item: 'minecraft:ender_pearl' },
+            ignore_crushing_multiplier: true,
+            result: {
+                type: 'occultism:item',
+                id: AlmostUnified.getTagTargetItem(`c:dusts/ender_pearl`).getId(),
+                count: 1
+            },
+            id: `${id_prefix}ender_pearl_dust`
+        },
+        {
+            ingredient: { item: 'ae2:sky_stone_block' },
+            ignore_crushing_multiplier: true,
+            result: {
+                type: 'occultism:item',
+                id: 'ae2:sky_dust',
+                count: 1
+            },
+            id: `${id_prefix}sky_dust`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/occultism/crushing.js
+++ b/kubejs/server_scripts/recipes/occultism/crushing.js
@@ -43,6 +43,16 @@ ServerEvents.recipes((event) => {
             id: `occultism:crushing/certus_quartz_dust_from_gem`
         },
         {
+            ingredient: { tag: 'c:gems/emerald' },
+            ignore_crushing_multiplier: true,
+            result: {
+                type: 'occultism:item',
+                id: AlmostUnified.getTagTargetItem(`c:dusts/emerald`).getId(),
+                count: 1
+            },
+            id: `occultism:crushing/emerald_dust_from_gem`
+        },
+        {
             ingredient: { tag: 'c:ores/black_quartz' },
             ignore_crushing_multiplier: false,
             result: {

--- a/kubejs/server_scripts/recipes/occultism/miner.js
+++ b/kubejs/server_scripts/recipes/occultism/miner.js
@@ -21,6 +21,16 @@ ServerEvents.recipes((event) => {
                 weight: 560
             },
             id: `${id_prefix}black_quartz`
+        },
+        {
+            ingredient: { tag: 'occultism:miners/ores' },
+            result: {
+                type: 'occultism:weighted_tag',
+                tag: 'c:ores/fluorite',
+                count: 1,
+                weight: 560
+            },
+            id: `${id_prefix}fluorite`
         }
     ];
 

--- a/kubejs/server_scripts/recipes/occultism/ritual.js
+++ b/kubejs/server_scripts/recipes/occultism/ritual.js
@@ -26,10 +26,12 @@ ServerEvents.recipes((event) => {
             recipe.id = recipe_id;
         } else if (recipe_id.includes('ritual/possess_warden')) {
             recipe.entity_to_sacrifice = {
-                display_name: 'ritual.occultism.sacrifice.bats',
-                tag: 'c:bats'
+                display_name: 'ritual.occultism.sacrifice.cows',
+                tag: 'c:cows'
             };
             recipe.ingredients = [
+                { item: 'minecraft:sculk' },
+                { item: 'minecraft:sculk' },
                 { item: 'minecraft:sculk' },
                 { item: 'minecraft:sculk' },
                 { item: 'minecraft:sculk' },

--- a/kubejs/server_scripts/recipes/occultism/shaped.js
+++ b/kubejs/server_scripts/recipes/occultism/shaped.js
@@ -1,0 +1,19 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'pneumaticcraft:occultism/shaped/';
+
+    const recipes = [
+        {
+            output: 'occultism:magic_lamp_empty',
+            pattern: [' A ', 'ABA', ' AA'],
+            key: {
+                A: '#c:ingots/silver',
+                B: '#c:ingots/iesnium'
+            },
+            id: `occultism:crafting/magic_lamp_empty`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/tags/entity_type/enigmatica/mob_spawner_blacklist.js
+++ b/kubejs/server_scripts/tags/entity_type/enigmatica/mob_spawner_blacklist.js
@@ -22,6 +22,7 @@ ServerEvents.tags('entity_type', (event) => {
             'occultism:afrit_wild',
             'occultism:otherworld_bird',
             'occultism:marid_unbound',
+            'occultism:mercy_goat',
             'evilcraft:netherfish',
             'evilcraft:poisonous_libelle',
             'evilcraft:werewolf'

--- a/kubejs/server_scripts/tags/item/neoforge/slimeballs.js
+++ b/kubejs/server_scripts/tags/item/neoforge/slimeballs.js
@@ -1,0 +1,5 @@
+ServerEvents.tags('item', (event) => {
+    let additions = ['actuallyadditions:rice_slimeball'];
+
+    event.get('c:slimeballs').add(additions);
+});

--- a/kubejs/startup_scripts/better_stacks.js
+++ b/kubejs/startup_scripts/better_stacks.js
@@ -9,6 +9,7 @@ ItemEvents.modification((event) => {
         'the_bumblezone:pollen_puff',
         /occultism:book_of_binding_(empty|foliot|djinni|afrit|marid)/,
         'occultism:soul_gem',
+        /enderio:.*_capacitor/,
 
         //signs
         /(minecraft|supplementaries|occultism|deeperdarker):\w+_sign/

--- a/kubejs/startup_scripts/better_stacks.js
+++ b/kubejs/startup_scripts/better_stacks.js
@@ -7,7 +7,8 @@ ItemEvents.modification((event) => {
         'minecraft:egg',
         'powah:charged_snowball',
         'the_bumblezone:pollen_puff',
-        'occultism:book_of_binding_empty',
+        /occultism:book_of_binding_(empty|foliot|djinni|afrit|marid)/,
+        'occultism:soul_gem',
 
         //signs
         /(minecraft|supplementaries|occultism|deeperdarker):\w+_sign/


### PR DESCRIPTION
- Add missing tin recipes
- Add more AA fuel support
- Add AA rice slimeballs to `#c:slimeballs`
-   Rice Slime Balls now count as slime balls for more recipes 
-   Expanded fuel support for AA, allowing it to burn more coal like substances 
-   Added more cross mod crushing compatibility 
-   AA Lasers no longer lose power during transmission 
-   Tiny TNT no longer breaks blocks, making it safer for crafting 
-   Glow Berries are now a source for yellow dye 
-   The Market has dropped their prices once again! Rejoice! 