### PR TITLE
Slow down dragon drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 -   Occultism chalk has been made unbreakable due to inability to see how damaged it is in a ritual bag [(\#213)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/213)
 -   Structory tower and arcane library loot has been buffed [(\#213)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/213)
 -   Theurgy Calcination and Distillation sped up to reduce number of machines needed [(\#217)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/217)
+-   Dragons in drygmy farms will now drop eggs, heads, and breath at a reduced rate [(\#218)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/218)
 
 #### 🦟 Bugs Fixed
 

--- a/kubejs/server_scripts/loot_tables/entities/minecraft/ender_dragon.js
+++ b/kubejs/server_scripts/loot_tables/entities/minecraft/ender_dragon.js
@@ -1,11 +1,9 @@
 // https://docs.almostreliable.com/lootjs/
-LootJS.lootTables((event) => {
-    event.getLootTable('minecraft:entities/ender_dragon').createPool((pool) => {
-        pool.addEntry(LootEntry.of('minecraft:dragon_egg').setCount(1));
-    });
-});
 
 LootJS.modifiers((event) => {
-    onlyDrygmy(event, 'minecraft:ender_dragon').addLoot('minecraft:dragon_head');
-    onlyDrygmy(event, 'minecraft:ender_dragon').setCount([1, 8]).addLoot('minecraft:dragon_breath');
+    notDrygmy(event, 'minecraft:ender_dragon').addLoot('minecraft:dragon_egg');
+
+    onlyDrygmy(event, 'minecraft:ender_dragon').randomChance(0.25).addLoot('minecraft:dragon_head');
+    onlyDrygmy(event, 'minecraft:ender_dragon').randomChance(0.25).addLoot('minecraft:dragon_egg');
+    onlyDrygmy(event, 'minecraft:ender_dragon').randomChance(0.5).setCount([1, 8]).addLoot('minecraft:dragon_breath');
 });


### PR DESCRIPTION
Dragons in drygmy farms will now drop eggs, heads, and breath at a reduced rate. 