### PR TITLE
Yeet Vengeance Spirits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   Tiny Coal and Tiny Charcoals are now unified [(\#221)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/221)
 -   Charcoal blocks are also unified [(\#227)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/227)
 -   Fix missing Extreme Reactors recipes [(\#227)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/227)
+-   Vengeance Spirits will no longer spawn unless using a Vengeance Ring [(\#233)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/233)
 
 ---
 

--- a/config/evilcraft-common.toml
+++ b/config/evilcraft-common.toml
@@ -302,7 +302,7 @@
 		#Whether vengeance spirits should always be visible in creative mode.
 		alwaysVisibleInCreative = false
 		#The maximum amount of vengeance spirits naturally spawnable in the spawnLimitArea.
-		spawnLimit = 5
+		spawnLimit = 0
 
 	[mob.werewolf]
 		#If villagers struck by lightning should have a 50% chance of becoming a werewolf villager


### PR DESCRIPTION
Apparently setting this to 0 will prevent Vengeance Spirits spawning unless the player is actually using EvilCraft tools to do so. 

![image](https://github.com/user-attachments/assets/c80b1dcd-bd68-49bc-bca2-4298ffabd8bc)

Considering you generally don't want them messing with things unless you're actually playing through EC, I think this is best. 