### PR TITLE
Aviars Circle requires 16 candles now instead of 4

### DIFF
--- a/config/ftbquests/quests/chapters/0095002B3E34FD9A.snbt
+++ b/config/ftbquests/quests/chapters/0095002B3E34FD9A.snbt
@@ -132,7 +132,7 @@
 					type: "advancement"
 				}
 				{
-					count: 4L
+					count: 16L
 					id: "53EE7D896F7103FA"
 					item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(minecraft:candles)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 					type: "item"


### PR DESCRIPTION
![Screenshot 2024-12-21 at 12 46 21](https://github.com/user-attachments/assets/dd893ec8-cdad-4362-86fe-576b728ffac9)
