### PR TITLE
uranium block heat fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 -   Fix typo in MI quests [(\#312)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/312)
 -   Remove now redundant tooltips from Iron's equipment [(\#314)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/314)
 -   Combiner ore dupe loop has been closed [(\#317)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/317)
+-   Uranium may once again be used as a heat source for PNC [(\#348)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/348)
 
 ---
 

--- a/kubejs/server_scripts/recipes/pneumaticcraft/heat_properties.js
+++ b/kubejs/server_scripts/recipes/pneumaticcraft/heat_properties.js
@@ -1,0 +1,19 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:pneumaticcraft/heat_properties/';
+
+    const recipes = [
+        {
+            block: 'modern_industrialization:uranium_block',
+            transforms: { cold: 'modern_industrialization:lead_block' },
+            heatCapacity: 500000,
+            temperature: 438,
+            thermalResistance: 500,
+            id: `${id_prefix}uranium_to_lead`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        recipe.type = `pneumaticcraft:heat_properties`;
+        event.custom(recipe).id(recipe.id);
+    });
+});


### PR DESCRIPTION
-   Uranium may once again be used as a heat source for PNC