### PR TITLE
Enchant Limiting

### DIFF
--- a/config/apotheosis/enchantments.cfg
+++ b/config/apotheosis/enchantments.cfg
@@ -370,7 +370,7 @@
 
     # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
     # Default: -1; Range: [-1 ~ 127]
-    I:"Forced Level Cap"=-1
+    I:"Forced Level Cap"=5
 }
 
 
@@ -784,7 +784,7 @@
 
     # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
     # Default: -1; Range: [-1 ~ 127]
-    I:"Forced Level Cap"=-1
+    I:"Forced Level Cap"=5
 }
 
 

--- a/config/apotheosis/enchantments.cfg
+++ b/config/apotheosis/enchantments.cfg
@@ -22,6 +22,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -41,6 +45,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -60,6 +68,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -79,6 +91,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=3
 }
 
 
@@ -98,6 +114,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -117,6 +137,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -136,6 +160,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=7
 }
 
 
@@ -155,6 +183,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -174,6 +206,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -193,6 +229,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -212,6 +252,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -231,6 +275,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -250,6 +298,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -269,6 +321,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -288,6 +344,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -307,6 +367,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -326,6 +390,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -345,6 +413,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -364,6 +436,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -383,6 +459,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -402,6 +482,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -421,6 +505,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -440,6 +528,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -459,6 +551,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -478,6 +574,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -497,6 +597,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=10
 }
 
 
@@ -516,6 +620,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -535,6 +643,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -554,6 +666,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -573,6 +689,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -592,6 +712,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -611,6 +735,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -630,6 +758,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -649,6 +781,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -668,6 +804,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -687,6 +827,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -706,6 +850,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=10
 }
 
 
@@ -725,6 +873,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -744,6 +896,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -763,6 +919,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -782,6 +942,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=10
 }
 
 
@@ -801,6 +965,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=10
 }
 
 
@@ -820,6 +988,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -839,6 +1011,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=5
 }
 
 
@@ -858,6 +1034,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -877,6 +1057,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -896,6 +1080,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -915,6 +1103,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -934,6 +1126,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -953,6 +1149,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -972,6 +1172,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -991,6 +1195,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1010,6 +1218,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1029,6 +1241,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1048,6 +1264,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1067,13 +1287,17 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
 "ars_nouveau:reactive" {
     # The max level of this enchantment - originally 4.
     # Default: 8; Range: [1 ~ 127]
-    I:"Max Level"=8
+    I:"Max Level"=4
 
     # The max level of this enchantment available from loot sources.
     # Default: 4; Range: [1 ~ 127]
@@ -1086,6 +1310,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=4
 }
 
 
@@ -1105,6 +1333,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1124,6 +1356,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1143,6 +1379,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1162,6 +1402,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1181,6 +1425,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=5
 }
 
 
@@ -1200,6 +1448,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1219,6 +1471,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1238,6 +1494,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1257,6 +1517,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1276,6 +1540,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1295,6 +1563,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1314,6 +1586,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1333,6 +1609,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1352,6 +1632,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1371,6 +1655,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1390,6 +1678,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1409,6 +1701,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1428,6 +1724,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1447,6 +1747,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1466,6 +1770,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1485,6 +1793,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1504,6 +1816,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1523,6 +1839,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 
@@ -1542,6 +1862,10 @@
     # A function to determine the min enchanting power.
     # Default: 
     S:"Min Power Function"=
+
+    # The enforced effective max level of this enchantment. Regardless of NBT and other buffs, this enchantment will never exceed this level. -1 to disable.
+    # Default: -1; Range: [-1 ~ 127]
+    I:"Forced Level Cap"=-1
 }
 
 


### PR DESCRIPTION
Newest Apothic Enchanting allows us to put an effective cap on enchants. This means that even if a feature, such as oritech, allows for over enchanting beyond this limit, the enchant will be limited to that level. 

I don't think it's worth applying this to every enchant, so protection and damage enchants are left uncapped. But I think it's best to put a reasonable cap on things like fortune and looting, as well as a few others that get crazy when left uncapped. 

Effective Caps:

- Berserker's Fury: 3
- Boon of Earth: 7
- Fortune: 10
- Looting: 10
- Mana Boost: 10
- Mana Regen: 10
- Miner's Fervor: 5
- Reactive: 4
- Scavenger: 5
- Knowledge of the Ages: 5
- Crescendo of Bolts: 5