### PR TITLE
Create copper recipe compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Enigmatica 10 1.24.0
 
+#### ⭐ Improvements
+
+-   Adds Create Copper recipe support to Mek, MI, and IE [(\#435)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/435)
+
 #### 🦟 Bugs Fixed
 
 -   Fix Extreme Reactors Fluidizer recipes [(\#419)](https://github.com/EnigmaticaModpacks/Enigmatica10/issues/419)

--- a/kubejs/server_scripts/constants/copper_types.js
+++ b/kubejs/server_scripts/constants/copper_types.js
@@ -1,0 +1,4 @@
+//priority: 1001
+
+const oxides = ['copper', 'exposed_copper', 'weathered_copper', 'oxidized_copper'];
+const copper_types = ['_shingles', '_shingle_slab', '_shingle_stairs', '_tiles', '_tile_slab', '_tile_stairs'];

--- a/kubejs/server_scripts/recipes/enigmatica/shapeless.js
+++ b/kubejs/server_scripts/recipes/enigmatica/shapeless.js
@@ -81,6 +81,16 @@ ServerEvents.recipes((event) => {
         }
     ];
 
+    copper_types.forEach((type) => {
+        oxides.forEach((oxide) => {
+            recipes.push({
+                output: `create:waxed_${oxide}${type}`,
+                inputs: [`create:${oxide}${type}`, 'modern_industrialization:wax'],
+                id: `${id_prefix}${oxide}${type}`
+            });
+        });
+    });
+
     recipes.forEach((recipe) => {
         let r = event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
         if (recipe.damage) r.damageIngredient(recipe.damage.item, recipe.damage.amount);

--- a/kubejs/server_scripts/recipes/immersiveengineering/bottling.js
+++ b/kubejs/server_scripts/recipes/immersiveengineering/bottling.js
@@ -1,0 +1,23 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:immersiveengineering/bottling/';
+
+    const recipes = [];
+
+    copper_types.forEach((type) => {
+        oxides.forEach((oxide, index) => {
+            if (index < oxides.length - 1) {
+                recipes.push({
+                    fluid: { tag: 'c:redstone_acid', amount: 125 },
+                    input: { item: `create:${oxide}${type}` },
+                    results: [{ item: `create:${oxides[index + 1]}${type}` }],
+                    id: `${id_prefix}${oxides[index + 1]}${type}`
+                });
+            }
+        });
+    });
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'immersiveengineering:bottling_machine';
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/recipes/mekanism/combiner.js
+++ b/kubejs/server_scripts/recipes/mekanism/combiner.js
@@ -1,0 +1,21 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:mekanism/combining/';
+
+    const recipes = [];
+
+    copper_types.forEach((type) => {
+        oxides.forEach((oxide) => {
+            recipes.push({
+                main_input: { item: `create:${oxide}${type}`, count: 1 },
+                extra_input: { count: 1, item: 'minecraft:honeycomb' },
+                output: { id: `create:waxed_${oxide}${type}`, count: 1 },
+                id: `${id_prefix}${oxide}${type}`
+            });
+        });
+    });
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'mekanism:combining';
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/recipes/mekanism/crushing.js
+++ b/kubejs/server_scripts/recipes/mekanism/crushing.js
@@ -1,10 +1,26 @@
-// ServerEvents.recipes((event) => {
-//     const id_prefix = 'enigmatica:mekanism/crushing/';
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:mekanism/crushing/';
 
-//     const recipes = [];
+    const recipes = [
+        // {
+        //     type: 'mekanism:crushing',
+        //     input: { count: 1, item: 'minecraft:waxed_chiseled_copper' },
+        //     output: { count: 1, id: 'minecraft:chiseled_copper' }
+        // }
+    ];
 
-//     recipes.forEach((recipe) => {
-//         recipe.type = 'mekanism:crushing';
-//         event.custom(recipe).id(recipe.id);
-//     });
-// });
+    copper_types.forEach((type) => {
+        oxides.forEach((oxide) => {
+            recipes.push({
+                input: { item: `create:waxed_${oxide}${type}`, count: 1 },
+                output: { id: `create:${oxide}${type}`, count: 1 },
+                id: `${id_prefix}${oxide}${type}`
+            });
+        });
+    });
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'mekanism:crushing';
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/recipes/mekanism/injecting.js
+++ b/kubejs/server_scripts/recipes/mekanism/injecting.js
@@ -1,0 +1,24 @@
+ServerEvents.recipes((event) => {
+    const id_prefix = 'enigmatica:mekanism/injecting/';
+
+    const recipes = [];
+
+    copper_types.forEach((type) => {
+        oxides.forEach((oxide, index) => {
+            if (index < oxides.length - 1) {
+                recipes.push({
+                    chemical_input: { chemical: 'mekanism:oxygen', amount: 1 },
+                    item_input: { item: `create:${oxide}${type}`, count: 1 },
+                    output: { id: `create:${oxides[index + 1]}${type}`, count: 1 },
+                    per_tick_usage: true,
+                    id: `${id_prefix}${oxides[index + 1]}${type}`
+                });
+            }
+        });
+    });
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'mekanism:injecting';
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/recipes/modern_industrialization/chemical_reactor.js
+++ b/kubejs/server_scripts/recipes/modern_industrialization/chemical_reactor.js
@@ -35,6 +35,31 @@ ServerEvents.recipes((event) => {
         }
     ];
 
+    copper_types.forEach((type) => {
+        oxides.forEach((oxide, index) => {
+            if (index < oxides.length - 1) {
+                recipes.push({
+                    item_inputs: [{ item: `create:${oxide}${type}`, amount: 1 }],
+                    fluid_inputs: [{ fluid: 'modern_industrialization:oxygen', amount: 100 }],
+                    item_outputs: { item: `create:${oxides[index + 1]}${type}`, amount: 1 },
+                    duration: 100,
+                    eu: 8,
+                    id: `${id_prefix}${oxides[index + 1]}${type}`
+                });
+            }
+            recipes.push({
+                item_inputs: [
+                    { item: `create:${oxide}${type}`, amount: 1 },
+                    { item: 'modern_industrialization:wax', amount: 1 }
+                ],
+                item_outputs: { item: `create:waxed_${oxide}${type}`, amount: 1 },
+                duration: 100,
+                eu: 8,
+                id: `${id_prefix}waxed_${oxide}${type}`
+            });
+        });
+    });
+
     recipes.forEach((recipe) => {
         recipe.type = 'modern_industrialization:chemical_reactor';
         event.custom(recipe).id(recipe.id);

--- a/kubejs/server_scripts/recipes/modern_industrialization/mixer.js
+++ b/kubejs/server_scripts/recipes/modern_industrialization/mixer.js
@@ -268,6 +268,19 @@ ServerEvents.recipes((event) => {
         });
     });
 
+    copper_types.forEach((type) => {
+        oxides.forEach((oxide) => {
+            recipes.push({
+                item_inputs: [{ item: `create:${oxide}${type}`, amount: 1 }],
+                fluid_inputs: [{ tag: 'c:honey', amount: 1 }],
+                item_outputs: [{ item: `create:waxed_${oxide}${type}`, amount: 1 }],
+                duration: 100,
+                eu: 2,
+                id: `${id_prefix}waxed_${oxide}${type}`
+            });
+        });
+    });
+
     recipes.forEach((recipe) => {
         recipe.type = 'modern_industrialization:mixer';
         event.custom(recipe).id(recipe.id);

--- a/kubejs/server_scripts/tags/block/neoforge/ores.js
+++ b/kubejs/server_scripts/tags/block/neoforge/ores.js
@@ -2,7 +2,9 @@ ServerEvents.tags('block', (event) => {
     let additions = {
         dark_gem: [/evilcraft:dark_ore/],
 
-        replica: ['replication:deepslate_replica_ore']
+        replica: ['replication:deepslate_replica_ore'],
+
+        quartz: ['kubejs:deepslate_quartz_ore']
     };
 
     Object.keys(additions).forEach((tag) => {

--- a/kubejs/server_scripts/tags/item/neoforge/ores.js
+++ b/kubejs/server_scripts/tags/item/neoforge/ores.js
@@ -2,7 +2,9 @@ ServerEvents.tags('item', (event) => {
     let additions = {
         uranium: ['oritech:deepslate_uranium_ore'],
 
-        replica: ['replication:deepslate_replica_ore']
+        replica: ['replication:deepslate_replica_ore'],
+
+        quartz: ['kubejs:deepslate_quartz_ore']
     };
 
     Object.keys(additions).forEach((tag) => {


### PR DESCRIPTION
Adds Create Copper recipe support to Mek, MI, and IE, allowing the blocks to be oxidized, waxed and scraped as per those mod's support for vanilla copper. 

https://github.com/EnigmaticaModpacks/Enigmatica10/issues/430