### PR TITLE
Add Java Headless Flag

### DIFF
--- a/server_files/server-setup-config.yaml
+++ b/server_files/server-setup-config.yaml
@@ -217,3 +217,4 @@ launch:
         - '-Daikars.new.flags=true'
         - '-Dfml.readTimeout=180' # servertimeout
         - '-Dfml.queryResult=confirm' # auto /fmlconfirm
+        - '-Djava.awt.headless=true'


### PR DESCRIPTION
Debugged a Java stack trace the length of 10 Earths to find a mod was trying to call gui elements from a headless JDK. Assuming headless is recommended/used universally for this application so submitting a pull request.